### PR TITLE
Rule Refactor

### DIFF
--- a/bracket.css
+++ b/bracket.css
@@ -1,0 +1,18 @@
+*:not(.bracket, .bracket *) {
+  visibility: collapse !important;
+  background: transparent !important;
+}
+
+.bracket,
+.bracket * {
+  visibility: visible !important;
+}
+
+.bracket {
+  position: fixed;
+  inset: 0;
+  background: transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/opinions.css
+++ b/opinions.css
@@ -1,0 +1,19 @@
+.bracket {
+  color: white;
+  transform: scale(2);
+}
+
+.progress-to,
+.progress-from {
+  color: black !important;
+  background: white;
+}
+
+.root-sggBAddL .titleContainer-sggCtPJ- .title-sggP5PgL,
+.root-sggBAddL .timeContainer-sggSCTWl {
+  color: white !important;
+}
+
+.RoundHeader-sggW-5vC.hidden-sggFw9x2 {
+  filter: opacity(0);
+}


### PR DESCRIPTION
This isn't fully ready to merge yet but this is the exact setup I used in a recent production. I'll be changing the readme to source the css and I may as well make an npm package out of it to just cause.

The way I use it now is via css `@import`. This will be enhanced by making it a package too, and you can still make tweaks on top of the import as well. bracket.css is the bare minimum isolation and opinions.css is what I applied on top. I'll also add some stuff for the styles you guys made.

![image](https://user-images.githubusercontent.com/2515630/208325114-c718040f-6138-4528-8c9c-f180c4c409d5.png)

Without opinions:
![image](https://user-images.githubusercontent.com/2515630/208324914-bc5cabb5-526e-4ae3-943c-7a20163f78cf.png)

With opinions:
![image](https://user-images.githubusercontent.com/2515630/208324946-6c7c07cf-b241-4215-9b56-347318b7901c.png)

Opinions still has a hard-coded zoom factor too. I'll be working on some CSS magic to make it scale to fit the content.

Everything subject to change! Can't recommend merging just yet!